### PR TITLE
add support for init containers, make webhook's namespace configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Makefile for building the Admission Controller webhook demo server and docker image.
-
 AWS_ACCOUNT_ID = $$(aws sts get-caller-identity --query Account --output text)
 AWS_REGION = $$(aws configure get region)
 IMAGE_NAME = $$(basename `pwd`)
+
+IMAGE_URL ?= "$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE_NAME):latest"
+NAMESPACE ?= "envhook"
 
 .DEFAULT_GOAL := image
 
@@ -35,13 +36,13 @@ push:
 	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE_NAME):latest
 
 tls:
-	deploy/tls.sh
+	NAMESPACE=${NAMESPACE} deploy/tls.sh
 
 deploy: undeploy
-	deploy/deploy.sh create
+	NAMESPACE=${NAMESPACE} IMAGE_URL=${IMAGE_URL} deploy/deploy.sh create
 
 undeploy:
-	deploy/deploy.sh delete
+	NAMESPACE=${NAMESPACE} IMAGE_URL=${IMAGE_URL} deploy/deploy.sh delete
 
 sample:
 	kubectl apply -f samples/namespace.yaml

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ kubectl exec -it -n samples deployment-123 -- env
 
 ```bash
 kubectl apply -f samples/statefulset.yaml
+kubectl logs -n samples statefulset-0 prober
 kubectl exec -it -n samples statefulset-0 -- env
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ kubectl logs -n samples pod-mixed compactor
 
 ```bash
 kubectl apply -f samples/deployment.yaml
-kubectl exec -it -n samples <<pod-name>> -- env
+kubectl logs -n samples deployment-123 prober
+kubectl exec -it -n samples deployment-123 -- env
 ```
 
 - Create a statefulset with a container that has a pre-existing configmap and secret and is allowed to receive env vars

--- a/cmd/envars-webhook/pod_patching.go
+++ b/cmd/envars-webhook/pod_patching.go
@@ -82,11 +82,9 @@ func patchPod(pod corev1.Pod) []patchOperation {
 
 	// Loop through the list of (init)containers and create a list of envFromSource patches
 	for i, container := range pod.Spec.InitContainers {
-		log.Printf(">>> looking at INIT container %s in pod %s", container.Name, pod.Name)
 		addSecretLabel, patches = patchContainer(container, podName(pod), i, addSecretLabel, secretName, patches, "initContainers")
 	}
 	for i, container := range pod.Spec.Containers {
-		log.Printf(">>> looking at container %s in pod %s", container.Name, pod.Name)
 		addSecretLabel, patches = patchContainer(container, podName(pod), i, addSecretLabel, secretName, patches, "containers")
 	}
 

--- a/cmd/envars-webhook/pod_patching.go
+++ b/cmd/envars-webhook/pod_patching.go
@@ -63,7 +63,7 @@ func podName(pod corev1.Pod) string {
 	if len(pod.Name) > 0 {
 		return pod.Name
 	}
-	return pod.GetGenerateName()
+	return pod.GetGenerateName() + "xxx"
 }
 
 // Create event: secret reference is added next to existing sources and secret name is stored in pod label

--- a/cmd/envars-webhook/pod_patching.go
+++ b/cmd/envars-webhook/pod_patching.go
@@ -75,7 +75,7 @@ func patchPod(pod corev1.Pod) []patchOperation {
 	// Loop through the list of (init)containers and create a list of envFromSource patches
 	for i, container := range pod.Spec.InitContainers {
 		log.Printf(">>> looking at INIT container %s in pod %s", container.Name, pod.Name)
-		addSecretLabel, patches = patchContainer(container, pod.Name, i, addSecretLabel, secretName, patches, "initcontainers")
+		addSecretLabel, patches = patchContainer(container, pod.Name, i, addSecretLabel, secretName, patches, "initContainers")
 	}
 	for i, container := range pod.Spec.Containers {
 		log.Printf(">>> looking at container %s in pod %s", container.Name, pod.Name)

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -23,10 +23,11 @@ basedir="$(dirname "$0")"
 
 # Read the PEM-encoded CA certificate from secret, base64 decode it and replace the `${CA_PEM_B64}` placeholder 
 # in the YAML template, then create the Kubernetes admission controller resources
-CA_PEM_B64="$(kubectl get secret -n webhook envars-webhook-tls -o 'go-template={{index .data "ca.crt"}}')"
-IMAGE_NAME="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.$(aws configure get region).amazonaws.com/$(basename `pwd`):latest"
+CA_PEM_B64="$(kubectl get secret -n ${NAMESPACE} envars-webhook-tls -o 'go-template={{index .data "ca.crt"}}')"
+
 sed -e 's@${CA_PEM_B64}@'"${CA_PEM_B64}"'@g' \
-  -e 's@${IMAGE_NAME}@'"${IMAGE_NAME}"'@g' < "${basedir}/deployment.yaml.template" \
+  -e 's@${IMAGE_URL}@'"${IMAGE_URL}"'@g' \
+  -e 's@${NAMESPACE}@'"${NAMESPACE}"'@g' < "${basedir}/deployment.yaml.template" \
   | kubectl $1 -f - || true
 
 echo "The webhook server has been $1d"

--- a/deploy/deployment.yaml.template
+++ b/deploy/deployment.yaml.template
@@ -2,19 +2,21 @@ apiVersion: v1
 kind: ConfigMap 
 metadata:
   name: webhook-config
-  namespace: webhook
+  namespace: ${NAMESPACE}
 data:
   config.yml: |
     verboseLogs: false
     containersAllowed:
+      compactor: false
       ingester: true
+      prober: false
       store-gateway: true
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envars-webhook
-  namespace: webhook
+  namespace: ${NAMESPACE}
   labels:
     app: envars-webhook
 spec:
@@ -32,7 +34,7 @@ spec:
         runAsUser: 65534
       containers:
       - name: server
-        image: ${IMAGE_NAME}
+        image: ${IMAGE_URL}
         imagePullPolicy: Always
         ports:
         - containerPort: 8443
@@ -55,7 +57,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: envars-webhook
-  namespace: webhook
+  namespace: ${NAMESPACE}
 spec:
   selector:
     app: envars-webhook
@@ -68,7 +70,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: envars-webhook
 webhooks:
-  - name: envars-webhook.webhook.svc
+  - name: envars-webhook.${NAMESPACE}.svc
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail
     sideEffects: None
@@ -76,7 +78,7 @@ webhooks:
     clientConfig:
       service:
         name: envars-webhook
-        namespace: webhook
+        namespace: ${NAMESPACE}
         path: "/mutate"
       caBundle: ${CA_PEM_B64}
     namespaceSelector:
@@ -112,4 +114,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: webhook
+    namespace: ${NAMESPACE}

--- a/deploy/deployment.yaml.template
+++ b/deploy/deployment.yaml.template
@@ -9,7 +9,7 @@ data:
     containersAllowed:
       compactor: false
       ingester: true
-      prober: false
+      prober: true
       store-gateway: true
 ---
 apiVersion: apps/v1

--- a/deploy/tls.sh
+++ b/deploy/tls.sh
@@ -32,7 +32,7 @@ req_extensions = v3_req
 distinguished_name = req_distinguished_name
 prompt = no
 [req_distinguished_name]
-CN = envars-webhook.webhook.svc
+CN = envars-webhook.${NAMESPACE}
 [ v3_req ]
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
@@ -40,35 +40,35 @@ extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 [alt_names]
 DNS.1 = envars-webhook
-DNS.2 = envars-webhook.webhook
-DNS.3 = envars-webhook.webhook.svc
-DNS.4 = envars-webhook.webhook.svc.cluster.local
+DNS.2 = envars-webhook.${NAMESPACE}
+DNS.3 = envars-webhook.${NAMESPACE}.svc
+DNS.4 = envars-webhook.${NAMESPACE}.svc.cluster.local
 EOF
 
 # Generate the CA cert and private key
-openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Admission Controller Webhook CA" -days 7300
+openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Admission Controller Webhook CA" -days 3650
 
 # Generate the private key for the webhook server
 openssl genrsa -out envars-webhook-tls.key 2048
 
 # Generate a Certificate Signing Request (CSR) for the private key, and sign it with the private key of the CA.
 openssl req -new -key envars-webhook-tls.key -subj "/CN=envars-webhook.webhook.svc" -config csr.conf \
-    | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out envars-webhook-tls.crt -extensions v3_req -extfile csr.conf -days 7300
+    | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out envars-webhook-tls.crt -extensions v3_req -extfile csr.conf -days 3650
 
 # Create the TLS secret for the keys that were generated
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: webhook
+  name: ${NAMESPACE}
   labels:
-    name: webhook
+    name: ${NAMESPACE}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: envars-webhook-tls
-  namespace: webhook
+  namespace: ${NAMESPACE}
 type: kubernetes.io/tls
 data:
   tls.key: $(cat ${key_dir}/envars-webhook-tls.key | base64 -w 0)

--- a/deploy/tls.sh
+++ b/deploy/tls.sh
@@ -14,7 +14,7 @@
 # tls.sh
 #
 # Generate a (self-signed) CA certificate and a certificate and private key to be used by the webhook server.
-# The certificate will be issued for the Common Name (CN) of `envars-webhook.webhook.svc`, which is the
+# The certificate will be issued for the Common Name (CN) of `envars-webhook.${NAMESPACE}.svc`, which is the
 # cluster-internal DNS name for the service.
 
 set -euo pipefail
@@ -46,13 +46,14 @@ DNS.4 = envars-webhook.${NAMESPACE}.svc.cluster.local
 EOF
 
 # Generate the CA cert and private key
-openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Admission Controller Webhook CA" -days 3650
+openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=envars-webhook-root-ca.${NAMESPACE}" -days 3650
 
 # Generate the private key for the webhook server
 openssl genrsa -out envars-webhook-tls.key 2048
+openssl genrsa -out envars-webhook-tls.key 2048
 
 # Generate a Certificate Signing Request (CSR) for the private key, and sign it with the private key of the CA.
-openssl req -new -key envars-webhook-tls.key -subj "/CN=envars-webhook.webhook.svc" -config csr.conf \
+openssl req -new -key envars-webhook-tls.key -subj "/CN=envars-webhook.${NAMESPACE}.svc" -config csr.conf \
     | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out envars-webhook-tls.crt -extensions v3_req -extfile csr.conf -days 3650
 
 # Create the TLS secret for the keys that were generated

--- a/samples/deployment.yaml
+++ b/samples/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: sample
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: sample
@@ -19,9 +19,17 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+      initContainers:
+        - name: prober
+          image: busybox
+          command: ["/bin/sh"]
+          args: ["-c", "env"]
+          envFrom:
+            - configMapRef:
+                name: env-configmap
       containers:
         - name: ingester
-          image: alpine
+          image: busybox
           command: ["/bin/sh"]
           args: ["-c", "sleep infinity"]
           envFrom:

--- a/samples/pod-allowed.yaml
+++ b/samples/pod-allowed.yaml
@@ -13,7 +13,7 @@ spec:
     runAsUser: 65534
   containers:
     - name: ingester
-      image: alpine
+      image: busybox
       command: ["/bin/sh"]
       args: ["-c", "env"]
       envFrom:

--- a/samples/pod-mixed.yaml
+++ b/samples/pod-mixed.yaml
@@ -14,20 +14,20 @@ spec:
   containers:
     - name: ingester
       image: busybox
+      command: ["/bin/sh"]
+      args: ["-c", "env"]
       envFrom:
         - configMapRef:
             name: env-configmap
         - secretRef:
             name: env-secrets
-      command: ["/bin/sh"]
-      args: ["-c", "env"]
     - name: store-gateway
       image: busybox
+      command: ["/bin/sh"]
+      args: ["-c", "env"]
       envFrom:
         - configMapRef:
             name: env-configmap
-      command: ["/bin/sh"]
-      args: ["-c", "env"]
     - name: compactor
       image: busybox
       command: ["/bin/sh"]

--- a/samples/pod-mixed.yaml
+++ b/samples/pod-mixed.yaml
@@ -19,16 +19,20 @@ spec:
       envFrom:
         - configMapRef:
             name: env-configmap
+    - name: store-gateway
+      image: busybox
+      command: ["/bin/sh"]
+      args: ["-c", "env"]
+      envFrom:
         - secretRef:
             name: env-secrets
-    - name: store-gateway
+    - name: compactor
       image: busybox
       command: ["/bin/sh"]
       args: ["-c", "env"]
       envFrom:
         - configMapRef:
             name: env-configmap
-    - name: compactor
-      image: busybox
-      command: ["/bin/sh"]
-      args: ["-c", "env"]
+        - secretRef:
+            name: env-secrets
+

--- a/samples/statefulset.yaml
+++ b/samples/statefulset.yaml
@@ -21,7 +21,7 @@ metadata:
     app: sample
 spec:
   serviceName: nginx
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: nginx
@@ -30,6 +30,14 @@ spec:
       labels:
         app: nginx
     spec:
+      initContainers:
+        - name: prober
+          image: busybox
+          command: ["/bin/sh"]
+          args: ["-c", "env"]
+          envFrom:
+            - configMapRef:
+                name: env-configmap
       containers:
         - name: store-gateway
           image: k8s.gcr.io/nginx-slim:0.8


### PR DESCRIPTION
- add support to expose node labels to init containers
- turn webhook namespace into a configurable parameter
- use image build from GHRC pipeline by default
- update test metadata and documentation
