### PR TITLE
Configurable namespace selector label

### DIFF
--- a/charts/envars-webhook/templates/mutatingwebhook.yaml
+++ b/charts/envars-webhook/templates/mutatingwebhook.yaml
@@ -24,7 +24,7 @@ webhooks:
       caBundle: {{ $ca.Cert | b64enc }}
     namespaceSelector:
       matchLabels:
-        name: {{ .Values.webhook.namespaceSelector }}
+        {{ .Values.webhook.namespaceSelectorLabel | default "name" }}: {{ .Values.webhook.namespaceSelector }}
     rules:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [""]

--- a/charts/envars-webhook/values.yaml
+++ b/charts/envars-webhook/values.yaml
@@ -37,7 +37,8 @@ service:
   type: ClusterIP
   port: 443
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -61,11 +62,13 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-  
+
 # Webhook settings
 webhook:
   # The namespace that the webhook would accept requests from
   namespaceSelector: samples
+  # The label to use for selecting namespace
+  # namespaceSelectorLabel: name
   # Show the JSON body for requests and responses in webhook logs
   verboseLogs: false
   # Map of container names allowed to receive node labels. False value or missing container name means node labels are not exposed.


### PR DESCRIPTION
Thanks for writing this utility! I'm surprised that this issue has not come up more frequently in the community as for stateful workloads knowing more about placement could be vital.

Our version of EKS has a different namespace selector label which makes the webhook configuration fail to match the proper events. 

This PR makes the NS selector label configurable but uses the old setting ("name") as the default.