### PR TITLE
support multiple namespaces - breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ webhooks:
   - name: envars-webhook.${NAMESPACE}.svc
     # [...]
     namespaceSelector:
-      matchLabels:
-        name: samples
+      matchExpressions:
+        - key: name
+          operator: In
+          values: ["samples"]
 ```
 
 - In deployment configmap, enable verbose logs to see the JSON body for request and response in server logs.

--- a/charts/envars-webhook/Chart.yaml
+++ b/charts/envars-webhook/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: envars-webhook
 description: Generate TLS cert and deploy the webhook
+home: "https://github.com/danfromtitan/envars-from-node-labels"
+sources: ["https://github.com/danfromtitan/envars-from-node-labels"]
 type: application
 appVersion: "0.1.0"
-version: 0.1.6
+version: 0.2.0

--- a/charts/envars-webhook/templates/mutatingwebhook.yaml
+++ b/charts/envars-webhook/templates/mutatingwebhook.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "envars-webhook.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "post-install,post-upgrade,pre-delete"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 webhooks:
   - name: {{ include "envars-webhook.name" . }}.{{ .Release.Namespace }}.svc
@@ -23,8 +23,13 @@ webhooks:
         path: "/mutate"
       caBundle: {{ $ca.Cert | b64enc }}
     namespaceSelector:
-      matchLabels:
-        {{ .Values.webhook.namespaceSelectorLabel | default "name" }}: {{ .Values.webhook.namespaceSelector }}
+      matchExpressions:
+        - key: {{ .Values.webhook.namespaceSelectorLabel }}
+          operator: In
+          values:
+          {{- with .Values.webhook.namespaceSelector }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
     rules:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [""]

--- a/charts/envars-webhook/values.yaml
+++ b/charts/envars-webhook/values.yaml
@@ -64,11 +64,12 @@ affinity: {}
 
 # Webhook settings
 webhook:
-  # The namespace that the webhook would accept requests from
-  namespaceSelector: samples
+  # The namespace(s) that the webhook would accept requests from.
+  namespaceSelector:
+    - samples
 
   # The label to use for selecting namespace
-  # namespaceSelectorLabel: name
+  namespaceSelectorLabel: name
 
   # Show the JSON body for requests and responses in webhook logs
   verboseLogs: false

--- a/deploy/deployment.yaml.template
+++ b/deploy/deployment.yaml.template
@@ -82,8 +82,10 @@ webhooks:
         path: "/mutate"
       caBundle: ${CA_PEM_B64}
     namespaceSelector:
-      matchLabels:
-        name: samples
+      matchExpressions:
+        - key: name
+          operator: In
+          values: ["samples"]
     rules:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [""]


### PR DESCRIPTION
This is a BREAKING CHANGE, because the type of `namespaceSelector` is changed from `string` to `array`

Rewrite the `MutatingWebhookConfiguration` to allow adding multiple namespaces.
Fixes https://github.com/danfromtitan/envars-from-node-labels/issues/16