### PR TITLE
remove helm hooks

### DIFF
--- a/charts/envars-webhook/Chart.yaml
+++ b/charts/envars-webhook/Chart.yaml
@@ -5,4 +5,4 @@ home: "https://github.com/danfromtitan/envars-from-node-labels"
 sources: ["https://github.com/danfromtitan/envars-from-node-labels"]
 type: application
 appVersion: "0.1.0"
-version: 0.2.0
+version: 0.2.1

--- a/charts/envars-webhook/templates/mutatingwebhook.yaml
+++ b/charts/envars-webhook/templates/mutatingwebhook.yaml
@@ -7,9 +7,6 @@ metadata:
   name: {{ include "envars-webhook.name" . }}
   labels:
     {{- include "envars-webhook.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade,pre-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 webhooks:
   - name: {{ include "envars-webhook.name" . }}.{{ .Release.Namespace }}.svc
     admissionReviewVersions: ["v1"]
@@ -44,9 +41,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "envars-webhook.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: kubernetes.io/tls
 data:
   tls.crt: {{ $cert.Cert | b64enc }}


### PR DESCRIPTION
After some trial and error I decided that having the Helm hooks there is not practical and causes issues.

The biggest issue is that resources deployed using Helm hooks are not removed when Helm release is uninstalled, so the `mutatingwebhookconfiguration` stays in the cluster, causes failures and needs to be manually removed.
