### PR TITLE
Add arm64 support

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,11 +11,6 @@ on:
         description: 'Go version'
         required: true
 
-permissions:
-  contents: read
-  id-token: write
-  packages: write
-
 jobs:
   changes:
     if: ${{ github.repository == 'danfromtitan/envars-from-node-labels' }}
@@ -69,6 +64,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ github.event.inputs.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-${{ github.event.inputs.go-version }}-
 
+      - run: make envars-webhook
+
       - id: docker-tags
         uses: docker/metadata-action@v4
         with:
@@ -94,7 +91,7 @@ jobs:
         id: docker-build
         with:
           context: ./
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker-tags.outputs.tags }}
           labels: ${{ steps.docker-tags.outputs.labels }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,6 +11,11 @@ on:
         description: 'Go version'
         required: true
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   changes:
     if: ${{ github.repository == 'danfromtitan/envars-from-node-labels' }}
@@ -64,8 +69,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ github.event.inputs.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-${{ github.event.inputs.go-version }}-
 
-      - run: make envars-webhook
-
       - id: docker-tags
         uses: docker/metadata-action@v4
         with:
@@ -91,7 +94,7 @@ jobs:
         id: docker-build
         with:
           context: ./
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker-tags.outputs.tags }}
           labels: ${{ steps.docker-tags.outputs.labels }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,6 +11,11 @@ on:
         description: 'Go version'
         required: true
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   changes:
     if: ${{ github.repository == 'danfromtitan/envars-from-node-labels' }}
@@ -88,11 +93,34 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/build-push-action@v3
-        id: docker-build
+        id: docker-build-amd
         with:
           context: ./
           platforms: linux/amd64
+          outputs: type=docker,push=false
+          tags: ${{ steps.docker-tags.outputs.tags }}
+          labels: ${{ steps.docker-tags.outputs.labels }}
+
+      - run: |
+          export GOARCH=arm64
+          make envars-webhook
+
+      - uses: docker/build-push-action@v3
+        id: docker-build-arm
+        with:
+          context: ./
+          platforms: linux/arm64
+          outputs: type=docker,push=false
+          tags: ${{ steps.docker-tags.outputs.tags }}
+          labels: ${{ steps.docker-tags.outputs.labels }}
+
+      - uses: docker/build-push-action@v3
+        id: docker-build
+        with:
+          context: ./
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
+          outputs: type=image,push=true
           tags: ${{ steps.docker-tags.outputs.tags }}
           labels: ${{ steps.docker-tags.outputs.labels }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.17 as builder
+FROM scratch
 
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
-
-WORKDIR /app
-COPY . /app
-RUN \
-    set -ex \
-    && GO111MODULE=on go get -v ./... \
-    && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" \
-        -o envars-webhook ./cmd/envars-webhook
-
-FROM --platform=${TARGETPLATFORM:-linux/amd64} scratch
-WORKDIR /
-COPY --from=builder /app/envars-webhook /envars-webhook
+COPY ./envars-webhook /
 ENTRYPOINT ["/envars-webhook"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
-FROM scratch
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.17 as builder
 
-COPY ./envars-webhook /
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /app
+COPY . /app
+RUN \
+    set -ex \
+    && GO111MODULE=on go get -v ./... \
+    && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" \
+        -o envars-webhook ./cmd/envars-webhook
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} scratch
+WORKDIR /
+COPY --from=builder /app/envars-webhook /envars-webhook
 ENTRYPOINT ["/envars-webhook"]


### PR DESCRIPTION
We're trying out AWS' gravitons, and I've noticed that the image is only build for amd64.

While testing build on my fork I could not push without permissions: block I've added currently.