### PR TITLE
Add failurePolicy variable for MutatingWebhookConfiguration

### DIFF
--- a/charts/envars-webhook/Chart.yaml
+++ b/charts/envars-webhook/Chart.yaml
@@ -5,4 +5,4 @@ home: "https://github.com/danfromtitan/envars-from-node-labels"
 sources: ["https://github.com/danfromtitan/envars-from-node-labels"]
 type: application
 appVersion: "0.1.0"
-version: 0.2.1
+version: 0.2.2

--- a/charts/envars-webhook/templates/mutatingwebhook.yaml
+++ b/charts/envars-webhook/templates/mutatingwebhook.yaml
@@ -10,7 +10,7 @@ metadata:
 webhooks:
   - name: {{ include "envars-webhook.name" . }}.{{ .Release.Namespace }}.svc
     admissionReviewVersions: ["v1"]
-    failurePolicy: Fail
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
     sideEffects: None
     timeoutSeconds: 30
     clientConfig:

--- a/charts/envars-webhook/values.yaml
+++ b/charts/envars-webhook/values.yaml
@@ -79,3 +79,6 @@ webhook:
     ingester: false
     prober: false
     store-gateway: false
+
+  # Defines how unrecognized errors and timeout errors from the admission webhook are handled. Allowed values are Ignore or Fail.
+  failurePolicy: Fail


### PR DESCRIPTION
In our case we have a fallback scenario when there are no environment variables that define kafka same AZ brokers, meaning we can still connect using a single URL with the list of them.

We also host some other pods that does not depend on the webhook in the same namespace that use this configuration. So it's fine for us to have failurePolicy set to `Ignore`, in fact absolutely neccessary as we had minor downtimes due to webhook misbehaving.

Currently when I set webhook replicas to 0 I can't manage the pods that does not depend on it, but running in the same namespace as namespaceSelector value, `Ignore` policy fixes it.