### PR TITLE
Add permissions to `contents: write`  for chart job

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -132,6 +132,8 @@ jobs:
 
   chart:
     needs: changes
+    permissions:
+      contents: write
     if: |
       (github.repository == 'danfromtitan/envars-from-node-labels') &&
       (needs.changes.outputs.chart == 'true')


### PR DESCRIPTION
https://github.com/danfromtitan/envars-from-node-labels/actions/runs/6615106387/job/17966565413#step:5:56.

References:

* https://github.com/helm/chart-releaser-action/issues/110#issue-1238764408
* https://github.com/helm/chart-releaser-action#example-workflow